### PR TITLE
let github build some binaries

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,32 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: Build
+      run: mkdir build && cd build && go build -v ..
+
+    - name: upload
+      uses: actions/upload-artifact@v1
+      with:
+        name: artifacts_${{ matrix.os }}
+        path: build


### PR DESCRIPTION
I don't want to install Go on my Windows machine, but I want to use this beautiful tool.
By adding a github action, github will build binaries for all supported OSes. At least the Windows one seems to be a static executable that runs without any extra infrastructure.
Downside: I'm not sure, but I guess just the repo owner can access build artifacts. Still, it might be a step into the direction of binary releases.