### PR TITLE
add badge and usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # veilig
 
+![Go CI](https://github.com/noqqe/veilig/workflows/Go/badge.svg)
+
 Toy tls certificate viewer that I built because openssl s_client confuses me
 
 Source available at: https://github.com/noqqe/veilig/
@@ -17,6 +19,12 @@ or
 ```
 brew tap noqqe/tap
 brew install veilig
+```
+
+## Use
+
+```
+veilig github.com:443
 ```
 
 ## License


### PR DESCRIPTION
Every good github project needs a badge in their `Readme.md`. Also, I added a complete chapter about usage.

Warning: the badge picture won't render unless you merge PR #1 - for a sneak preview, see https://github.com/knilch0r/veilig/tree/knilch0r-addbadge