### PR TITLE
removed '?' from output 'Is CA?: true/false'

### DIFF
--- a/veilig/root.go
+++ b/veilig/root.go
@@ -34,7 +34,7 @@ func printCertificate(cert *x509.Certificate) bool {
 	fmt.Printf("Valid from:%s\t%s%s\n", Yellow, cert.NotBefore, Reset)
 	fmt.Printf("Valid until:%s\t%s%s\n", Yellow, cert.NotAfter, Reset)
 	fmt.Printf("Issuer:%s\t\t%s%s\n", Cyan, cert.Issuer.Organization[0], Reset)
-	fmt.Printf("Is CA?:%s\t\t%t%s\n", Pink, cert.IsCA, Reset)
+	fmt.Printf("Is CA:%s\t\t%t%s\n", Pink, cert.IsCA, Reset)
 	fmt.Printf("Algorithm:%s\t%s%s\n", Pink, cert.SignatureAlgorithm, Reset)
 
 	if len(cert.DNSNames) > 0 {


### PR DESCRIPTION
the output states 'Is CA?:'  where I find the question mark not needed/of value but more confusing as of why is there no question mark after 'Name Valid'?.